### PR TITLE
Change default base URL for static file serving

### DIFF
--- a/src/constants/urls.js
+++ b/src/constants/urls.js
@@ -1,3 +1,3 @@
-const BASE_URL = "https://labephoto.herokuapp.com";
+const BASE_URL = process.env.REACT_APP_BASE_URL ||  "";
 
 export default BASE_URL;


### PR DESCRIPTION
Change the default BASE_URL to be empty so that the static UI files can be
served by the backend server (see gdmusse/labephoto-back-end#16). This default
value can be overriden by setting the `REACT_APP_BASE_URL` env var.